### PR TITLE
avatar: fix setting initial avatar URL

### DIFF
--- a/mautrix_facebook/db/portal.py
+++ b/mautrix_facebook/db/portal.py
@@ -55,6 +55,8 @@ class Portal:
     photo_id: Optional[str]
     avatar_url: Optional[ContentURI]
     encrypted: bool
+    name_set: bool
+    avatar_set: bool
 
     @classmethod
     def _from_row(cls, row: Optional[Record]) -> Optional['Portal']:
@@ -66,38 +68,43 @@ class Portal:
 
     @classmethod
     async def get_by_fbid(cls, fbid: int, fb_receiver: int) -> Optional['Portal']:
-        q = ("SELECT fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, encrypted "
+        q = ("SELECT fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, encrypted, "
+             "       name_set, avatar_set "
              "FROM portal WHERE fbid=$1 AND fb_receiver=$2")
         row = await cls.db.fetchrow(q, fbid, fb_receiver)
         return cls._from_row(row)
 
     @classmethod
     async def get_by_mxid(cls, mxid: RoomID) -> Optional['Portal']:
-        q = ("SELECT fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, encrypted "
+        q = ("SELECT fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, encrypted, "
+             "       name_set, avatar_set "
              "FROM portal WHERE mxid=$1")
         row = await cls.db.fetchrow(q, mxid)
         return cls._from_row(row)
 
     @classmethod
     async def get_all_by_receiver(cls, fb_receiver: int) -> List['Portal']:
-        q = ("SELECT fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, encrypted "
+        q = ("SELECT fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, encrypted, "
+             "       name_set, avatar_set "
              "FROM portal WHERE fb_receiver=$1 AND fb_type='USER'")
         rows = await cls.db.fetch(q, fb_receiver)
         return [cls._from_row(row) for row in rows]
 
     @classmethod
     async def all(cls) -> List['Portal']:
-        q = ("SELECT fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, encrypted "
+        q = ("SELECT fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, encrypted, "
+             "       name_set, avatar_set "
              "FROM portal")
         rows = await cls.db.fetch(q)
         return [cls._from_row(row) for row in rows]
 
     async def insert(self) -> None:
         q = ("INSERT INTO portal (fbid, fb_receiver, fb_type, mxid, name, photo_id, avatar_url, "
-             "                    encrypted) "
-             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)")
+             "                    encrypted, name_set, avatar_set) "
+             "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)")
         await self.db.execute(q, self.fbid, self.fb_receiver, self.fb_type.name, self.mxid,
-                              self.name, self.photo_id, self.avatar_url, self.encrypted)
+                              self.name, self.photo_id, self.avatar_url, self.encrypted,
+                              self.name_set, self.avatar_set)
 
     async def delete(self) -> None:
         q = "DELETE FROM portal WHERE fbid=$1 AND fb_receiver=$2"
@@ -105,7 +112,7 @@ class Portal:
 
     async def save(self) -> None:
         await self.db.execute("UPDATE portal SET mxid=$3, name=$4, photo_id=$5, avatar_url=$6,"
-                              "                  encrypted=$7 "
+                              "                  encrypted=$7, name_set=$8, avatar_set=$9 "
                               "WHERE fbid=$1 AND fb_receiver=$2",
                               self.fbid, self.fb_receiver, self.mxid, self.name, self.photo_id,
-                              self.avatar_url, self.encrypted)
+                              self.avatar_url, self.encrypted, self.name_set, self.avatar_set)

--- a/mautrix_facebook/db/upgrade/__init__.py
+++ b/mautrix_facebook/db/upgrade/__init__.py
@@ -2,4 +2,4 @@ from mautrix.util.async_db import UpgradeTable
 
 upgrade_table = UpgradeTable()
 
-from . import v01_initial_revision, v02_message_oti
+from . import v01_initial_revision, v02_message_oti, v03_portal_meta_set

--- a/mautrix_facebook/db/upgrade/v03_portal_meta_set.py
+++ b/mautrix_facebook/db/upgrade/v03_portal_meta_set.py
@@ -1,0 +1,26 @@
+# mautrix-facebook - A Matrix-Facebook Messenger puppeting bridge.
+# Copyright (C) 2021 Tulir Asokan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from asyncpg import Connection
+from . import upgrade_table
+
+
+@upgrade_table.register(description="Add name_set and avatar_set to message table")
+async def upgrade_v3(conn: Connection) -> None:
+    await conn.execute("ALTER TABLE portal ADD COLUMN name_set BOOLEAN NOT NULL DEFAULT false")
+    await conn.execute("ALTER TABLE portal ADD COLUMN avatar_set BOOLEAN NOT NULL DEFAULT false")
+    await conn.execute("UPDATE portal SET name_set=true WHERE name<>''")
+    # We don't set avatar_set to true because there was a bug that caused avatars to be set
+    # incorrectly, so we want everything to be reset.

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -448,7 +448,7 @@ class Portal(DBPortal, BasePortal):
         if self.encrypted or not self.is_direct:
             name = self.name
             initial_state.append({"type": str(EventType.ROOM_AVATAR),
-                                  "content": {"avatar_url": self.avatar_url}})
+                                  "content": {"url": self.avatar_url}})
         if self.config["appservice.community_id"]:
             initial_state.append({
                 "type": "m.room.related_groups",


### PR DESCRIPTION
Should I create a migration that blows away all of the `photo_id`s on all of the chats so that all of the chat avatars get updated?