### PR TITLE
Always refresh MQTT connection, sleeping between attempts as required.

### DIFF
--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -621,8 +621,7 @@ class User(DBUser, BaseUser):
                                               error_code="fb-disconnected")
         except (MQTTNotLoggedIn, MQTTNotConnected) as e:
             self.log.debug("Listen threw a Facebook error", exc_info=True)
-            refresh = (self.config["bridge.refresh_on_reconnection_fail"]
-                       and self._prev_reconnect_fail_refresh + 120 < time.monotonic())
+            refresh = self.config["bridge.refresh_on_reconnection_fail"]
             next_action = ("Refreshing session..." if refresh else "Not retrying!")
             event = ("Disconnected from" if isinstance(e, MQTTNotLoggedIn)
                      else "Failed to connect to")
@@ -635,6 +634,7 @@ class User(DBUser, BaseUser):
             elif self.temp_disconnect_notices:
                 await self.send_bridge_notice(message)
             if refresh:
+                await asyncio.sleep(self._prev_reconnect_fail_refresh + 120 - time.monotonic())
                 self._prev_reconnect_fail_refresh = time.monotonic()
                 asyncio.create_task(self.refresh())
             else:


### PR DESCRIPTION
This should prevent the bridge becoming stuck when the MQTT connection
fails more than once in a two minute window.

Perhaps we should add a new setting to have a max number of attempts as well?