### PR TITLE
Min connected time before periodic reconnect

### DIFF
--- a/mautrix_facebook/config.py
+++ b/mautrix_facebook/config.py
@@ -101,6 +101,7 @@ class Config(BaseBridgeConfig):
             copy("bridge.periodic_reconnect.interval")
             copy("bridge.periodic_reconnect.mode")
             copy("bridge.periodic_reconnect.always")
+            copy("bridge.periodic_reconnect.min_connected_time")
         copy("bridge.resync_max_disconnected_time")
         copy("bridge.temporary_disconnect_notices")
         copy("bridge.disable_bridge_notices")

--- a/mautrix_facebook/example-config.yaml
+++ b/mautrix_facebook/example-config.yaml
@@ -219,6 +219,8 @@ bridge:
         mode: refresh
         # Should even disconnected users be reconnected?
         always: false
+        # Only reconnect if the user has been connected for longer than this value
+        min_connected_time: 0
     # The number of seconds that a disconnection can last without triggering an automatic re-sync
     # and missed message backfilling when reconnecting.
     # Set to 0 to always re-sync, or -1 to never re-sync automatically.

--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -158,6 +158,10 @@ class User(DBUser, BaseUser):
             self._is_connected = val
             self._connection_time = time.monotonic()
 
+    @property
+    def connection_time(self) -> float:
+        return self._connection_time
+
     # region Database getters
 
     def _add_to_cache(self) -> None:


### PR DESCRIPTION
Stops the periodic reconnect task reconnecting for users that reconnected recently.