### PR TITLE
Remove Loop Parameter from asyncio high-level api.

### DIFF
--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -194,8 +194,7 @@ class Portal(DBPortal, BasePortal):
         changed = False
         if not self.is_direct:
             changed = any(await asyncio.gather(self._update_name(info.name),
-                                               self._update_photo(source, info.image),
-                                               loop=self.loop))
+                                               self._update_photo(source, info.image)))
         changed = await self._update_participants(source, info) or changed
         if changed:
             await self.update_bridge_info()
@@ -798,7 +797,7 @@ class Portal(DBPortal, BasePortal):
         # stopped_typing = [self.thread_for(user).stop_typing() for user in self._typing - users]
         # started_typing = [self.thread_for(user).start_typing() for user in users - self._typing]
         # self._typing = users
-        # await asyncio.gather(*stopped_typing, *started_typing, loop=self.loop)
+        # await asyncio.gather(*stopped_typing, *started_typing)
 
     async def enable_dm_encryption(self) -> bool:
         ok = await super().enable_dm_encryption()

--- a/mautrix_facebook/puppet.py
+++ b/mautrix_facebook/puppet.py
@@ -78,7 +78,7 @@ class Puppet(DBPuppet, BasePuppet):
         # Make the user join all private chat portals.
         await asyncio.gather(*[self.intent.ensure_joined(portal.mxid)
                                async for portal in p.Portal.get_all_by_receiver(self.fbid)
-                               if portal.mxid], loop=self.loop)
+                               if portal.mxid])
 
     def intent_for(self, portal: 'p.Portal') -> IntentAPI:
         if portal.fbid == self.fbid or (portal.backfill_lock.locked


### PR DESCRIPTION
This has been removed in python 3.10: https://docs.python.org/3/whatsnew/3.10.html#removed .

Because of this, when running on python 3.10 the bridge has a bug where portals do not get created, an users friendly names do not get set.

This parameter has been optional since at least python [3.5](https://docs.python.org/3.5/library/asyncio-task.html#task-functions).

Since Python 3.7 it has been ignored anyway, with the default event being used, which has always been the behaviour if it was ommitted.