### PR TITLE
checkpoints: send UNSUPPORTED for unsupported actions

### DIFF
--- a/mautrix_facebook/formatter/from_facebook.py
+++ b/mautrix_facebook/formatter/from_facebook.py
@@ -133,7 +133,7 @@ async def facebook_to_matrix(msg: Union[graphql.MessageText, mqtt.Message]) -> T
         text = msg.text
         mentions = msg.ranges
     else:
-        raise ValueError(f"Unsupported Facebook message type {type(msg).__name__}")
+        raise NotImplementedError(f"Unsupported Facebook message type {type(msg).__name__}")
     text = text or ""
     content = TextMessageEventContent(msgtype=MessageType.TEXT, body=text)
     mention_user_ids = []

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -597,6 +597,8 @@ class Portal(DBPortal, BasePortal):
 
     async def _handle_matrix_message(self, orig_sender: 'u.User', message: MessageEventContent,
                                      event_id: EventID) -> None:
+        if message.get_edit():
+            raise NotImplementedError("Edits are not supported by the Facebook bridge.")
         sender, is_relay = await self.get_relay_sender(orig_sender, f"message {event_id}")
         if not sender:
             raise Exception("not logged in")


### PR DESCRIPTION
sends UNSUPPORTED in the following cases:

* sending an edit
* unsupported message type
* attempting to redact a non message/reaction event

Also sends SUCCESS if reaction was same as already sent reaction

Also refactors some things to reduce code duplication