### PR TITLE
Persist BAD_CREDENTIALS bridge state after bridge restart

### DIFF
--- a/mautrix_facebook/db/user.py
+++ b/mautrix_facebook/db/user.py
@@ -52,7 +52,7 @@ class User:
     async def all_logged_in(cls) -> list[User]:
         q = """
             SELECT mxid, fbid, state, notice_room FROM "user"
-            WHERE fbid<>0 AND state IS NOT NULL
+            WHERE fbid<>0
         """
         rows = await cls.db.fetch(q)
         return [cls._from_row(row) for row in rows]

--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -260,7 +260,7 @@ class User(DBUser, BaseUser):
             await self.push_bridge_state(
                 BridgeStateEvent.BAD_CREDENTIALS,
                 error="fb-auth-error",
-                message="Bridge has restarted in BAD_CREDENTIALS state. Please delete and log in again."
+                message="Bridge has restarted in BAD_CREDENTIALS state. Please delete and log in again.",
             )
             return False
         attempt = 0

--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -255,6 +255,13 @@ class User(DBUser, BaseUser):
         if self._is_logged_in and not _override:
             return True
         elif not self.state:
+            # If we have a user in the DB with no state, we can assume
+            # FB logged us out and the bridge has restarted
+            await self.push_bridge_state(
+                BridgeStateEvent.BAD_CREDENTIALS,
+                error="fb-auth-error",
+                message="Bridge has restarted in BAD_CREDENTIALS state. Please delete and log in again."
+            )
             return False
         attempt = 0
         client = AndroidAPI(self.state, log=self.log.getChild("api"))

--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -259,8 +259,7 @@ class User(DBUser, BaseUser):
             # FB logged us out and the bridge has restarted
             await self.push_bridge_state(
                 BridgeStateEvent.BAD_CREDENTIALS,
-                error="fb-auth-error",
-                message="Bridge has restarted in BAD_CREDENTIALS state. Please delete and log in again.",
+                error="logged-out",
             )
             return False
         attempt = 0


### PR DESCRIPTION
Achieved this by pushing BAD_CREDENTIALS for users that have an fbid in
the database, but no "state" (fake Android device state).

Had to tweak the User.all_logged_in query to return users that are
missing state so we can detect this condition.