### PR TITLE
Backfill rooms on refresh with no messages

### DIFF
--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -1812,8 +1812,6 @@ class Portal(DBPortal, BasePortal):
         most_recent = await DBMessage.get_most_recent(self.fbid, self.fb_receiver)
         if most_recent and is_initial:
             self.log.debug("Not backfilling %s: already bridged messages found", self.fbid_log)
-        elif (not most_recent or not most_recent.timestamp) and not is_initial:
-            self.log.debug("Not backfilling %s: no most recent message found", self.fbid_log)
         elif last_active and most_recent.timestamp >= last_active:
             self.log.debug(
                 "Not backfilling %s: last activity is equal to most recent bridged "

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -1812,7 +1812,7 @@ class Portal(DBPortal, BasePortal):
         most_recent = await DBMessage.get_most_recent(self.fbid, self.fb_receiver)
         if most_recent and is_initial:
             self.log.debug("Not backfilling %s: already bridged messages found", self.fbid_log)
-        elif last_active and most_recent.timestamp >= last_active:
+        elif last_active and most_recent != None and most_recent.timestamp >= last_active:
             self.log.debug(
                 "Not backfilling %s: last activity is equal to most recent bridged "
                 "message (%s >= %s)",


### PR DESCRIPTION
When Facebook throws RateLimiting errors, it's common for the bridge to create the room, but no messages in it. If users then use `refresh` in the bridge room or restarts the bridge, they expect that the bridge continues backfilling messages where it had left of. Fixes #182.