### PR TITLE
MQTT: fix request timeout

### DIFF
--- a/maufbapi/mqtt/conn.py
+++ b/maufbapi/mqtt/conn.py
@@ -610,7 +610,7 @@ class AndroidMQTT:
         )
         fut = self._loop.create_future()
         timeout_handle = self._loop.call_later(REQUEST_TIMEOUT, self._cancel_later, fut)
-        fut.add_done_callback(timeout_handle.cancel)
+        fut.add_done_callback(lambda _: timeout_handle.cancel())
         self._publish_waiters[info.mid] = fut
         return fut
 
@@ -626,7 +626,7 @@ class AndroidMQTT:
             self._response_waiters[response] = fut
             await self.publish(topic, payload, prefix)
             timeout_handle = self._loop.call_later(REQUEST_TIMEOUT, self._cancel_later, fut)
-            fut.add_done_callback(timeout_handle.cancel)
+            fut.add_done_callback(lambda _: timeout_handle.cancel())
             return await fut
 
     @staticmethod


### PR DESCRIPTION
The callback passed via Future.add_done_callback is called with the Future instance as argument.

Without this fix, a lot of errors are thrown, which I catch with `loop.set_exception_handler()`.

```
{'message': 'Exception in callback TimerHandle.cancel(<Future finished result=None>)',
'exception': TypeError('cancel() takes 1 positional argument but 2 were given'),
'handle': <Handle TimerHandle.cancel(<Future finished result=None>)>}
```

This can be "hidden" when not using a custom exception handler, which I guess what mautrix-facebook does?