### PR TITLE
Add config parameter to disable bridging m.notice-type messages

### DIFF
--- a/mautrix_facebook/config.py
+++ b/mautrix_facebook/config.py
@@ -111,7 +111,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.max_startup_thread_sync_count")
         copy("bridge.temporary_disconnect_notices")
         copy("bridge.disable_bridge_notices")
-        copy("bridge.bridge_notices")
+        copy("bridge.bridge_matrix_notices")
         if "bridge.refresh_on_reconnection_fail" in self:
             base["bridge.on_reconnection_fail.action"] = (
                 "refresh" if self["bridge.refresh_on_reconnection_fail"] else None

--- a/mautrix_facebook/config.py
+++ b/mautrix_facebook/config.py
@@ -111,6 +111,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.max_startup_thread_sync_count")
         copy("bridge.temporary_disconnect_notices")
         copy("bridge.disable_bridge_notices")
+        copy("bridge.bridge_notices")
         if "bridge.refresh_on_reconnection_fail" in self:
             base["bridge.on_reconnection_fail.action"] = (
                 "refresh" if self["bridge.refresh_on_reconnection_fail"] else None

--- a/mautrix_facebook/example-config.yaml
+++ b/mautrix_facebook/example-config.yaml
@@ -257,6 +257,8 @@ bridge:
     temporary_disconnect_notices: false
     # Disable bridge notices entirely
     disable_bridge_notices: false
+    # Should Matrix m.notice-type messages be bridged?
+    bridge_notices: true
     on_reconnection_fail:
         # What to do if a reconnection attempt fails? Options: reconnect, refresh, null
         action: reconnect

--- a/mautrix_facebook/example-config.yaml
+++ b/mautrix_facebook/example-config.yaml
@@ -257,8 +257,8 @@ bridge:
     temporary_disconnect_notices: false
     # Disable bridge notices entirely
     disable_bridge_notices: false
-    # Should Matrix m.notice-type messages be bridged?
-    bridge_notices: true
+    # Should Matrix m.notice-type messages be bridged to Facebook?
+    bridge_matrix_notices: true
     on_reconnection_fail:
         # What to do if a reconnection attempt fails? Options: reconnect, refresh, null
         action: reconnect

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -1277,7 +1277,10 @@ class Portal(DBPortal, BasePortal):
         converted = await matrix_to_facebook(message, self.mxid, self.log)
         dbm = await self._make_dbm(sender, event_id)
 
-        if message.msgtype == MessageType.NOTICE and not self.config["bridge.bridge_notices"]:
+        if (
+            message.msgtype == MessageType.NOTICE
+            and not self.config["bridge.bridge_matrix_notices"]
+        ):
             return
 
         resp = await sender.mqtt.send_message(

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -1276,6 +1276,10 @@ class Portal(DBPortal, BasePortal):
     ) -> None:
         converted = await matrix_to_facebook(message, self.mxid, self.log)
         dbm = await self._make_dbm(sender, event_id)
+
+        if message.msgtype == MessageType.NOTICE and not self.config["bridge.bridge_notices"]:
+            return
+
         resp = await sender.mqtt.send_message(
             self.fbid,
             self.fb_type != ThreadType.USER,

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -1274,14 +1274,13 @@ class Portal(DBPortal, BasePortal):
     async def _handle_matrix_text(
         self, event_id: EventID, sender: u.User, message: TextMessageEventContent
     ) -> None:
-        converted = await matrix_to_facebook(message, self.mxid, self.log)
-        dbm = await self._make_dbm(sender, event_id)
-
         if (
             message.msgtype == MessageType.NOTICE
             and not self.config["bridge.bridge_matrix_notices"]
         ):
             return
+        converted = await matrix_to_facebook(message, self.mxid, self.log)
+        dbm = await self._make_dbm(sender, event_id)
 
         resp = await sender.mqtt.send_message(
             self.fbid,


### PR DESCRIPTION
Added feature for m.notice-type messages not be bridged