### PR TITLE
Allow setting segment_user_id in config

### DIFF
--- a/mautrix_facebook/__main__.py
+++ b/mautrix_facebook/__main__.py
@@ -63,10 +63,12 @@ class MessengerBridge(Bridge):
         if self.config["appservice.public.enabled"]:
             secret = self.config["appservice.public.shared_secret"]
             segment_key = self.config["appservice.public.segment_key"]
+            segment_user_id = self.config["appservice.public.segment_user_id"]
             self.public_website = PublicBridgeWebsite(
                 loop=self.loop,
                 shared_secret=secret,
                 segment_key=segment_key,
+                segment_user_id=segment_user_id,
             )
             self.az.app.add_subapp(
                 self.config["appservice.public.prefix"], self.public_website.app

--- a/mautrix_facebook/config.py
+++ b/mautrix_facebook/config.py
@@ -54,6 +54,7 @@ class Config(BaseBridgeConfig):
             copy("appservice.public.shared_secret")
         copy("appservice.public.allow_matrix_login")
         copy("appservice.public.segment_key")
+        copy("appservice.public.segment_user_id")
 
         copy("metrics.enabled")
         copy("metrics.listen_port")

--- a/mautrix_facebook/example-config.yaml
+++ b/mautrix_facebook/example-config.yaml
@@ -67,6 +67,8 @@ appservice:
         # Segment API key to enable analytics tracking for web server endpoints. Set to null to disable.
         # Currently the only events are login start, success and fail.
         segment_key: null
+        # Optional user_id to use when sending Segment events. If null, defaults to using mxID.
+        segment_user_id: null
 
     # The unique ID of this appservice.
     id: facebook

--- a/mautrix_facebook/web/public.py
+++ b/mautrix_facebook/web/public.py
@@ -46,14 +46,18 @@ class PublicBridgeWebsite:
     ready_wait: asyncio.Future | None
 
     def __init__(
-        self, shared_secret: str, segment_key: str | None, loop: asyncio.AbstractEventLoop
+        self,
+        shared_secret: str,
+        segment_key: str | None,
+        segment_user_id: str | None,
+        loop: asyncio.AbstractEventLoop,
     ) -> None:
         self.app = web.Application()
         self.ready_wait = loop.create_future()
         self.secret_key = "".join(random.choices(string.ascii_lowercase + string.digits, k=64))
         self.shared_secret = shared_secret
         if segment_key:
-            init_segment(segment_key)
+            init_segment(segment_key, segment_user_id)
         for path in (
             "whoami",
             "login",

--- a/mautrix_facebook/web/segment_analytics.py
+++ b/mautrix_facebook/web/segment_analytics.py
@@ -12,13 +12,14 @@ log = logging.getLogger("mau.web.public.analytics")
 segment_url: URL = URL("https://api.segment.io/v1/track")
 http: aiohttp.ClientSession | None = None
 segment_key: str | None = None
+segment_user_id: str | None = None
 
 
 async def _track(user: u.User, event: str, properties: dict) -> None:
     await http.post(
         segment_url,
         json={
-            "userId": user.mxid,
+            "userId": segment_user_id or user.mxid,
             "event": event,
             "properties": {"bridge": "facebook", **properties},
         },
@@ -32,7 +33,8 @@ def track(user: u.User, event: str, properties: dict | None = None):
         asyncio.create_task(_track(user, event, properties or {}))
 
 
-def init(key):
-    global segment_key, http
+def init(key, user_id: str | None = None):
+    global segment_key, segment_user_id, http
     segment_key = key
+    segment_user_id = user_id
     http = aiohttp.ClientSession()


### PR DESCRIPTION
Allow changing the user_id that is sent with Segment events, but still default to mxID if this new config value isn't set.