### PR TITLE
Add option to convert webp images to gifs

### DIFF
--- a/mautrix_facebook/config.py
+++ b/mautrix_facebook/config.py
@@ -142,6 +142,8 @@ class Config(BaseBridgeConfig):
             if isinstance(value, list) and len(value) != 2:
                 raise ValueError(f"{key} must only be a list of two items")
 
+        copy("bridge.convert_animated_webp_attachments")
+
         copy("facebook.device_seed")
         if base["facebook.device_seed"] == "generate":
             base["facebook.device_seed"] = self._new_token()

--- a/mautrix_facebook/example-config.yaml
+++ b/mautrix_facebook/example-config.yaml
@@ -365,6 +365,10 @@ bridge:
             m.video: '<b>$sender_displayname</b> sent a video'
             m.location: '<b>$sender_displayname</b> sent a location'
 
+    # Whether to convert animated webp to gifs. Element for Android does not support
+    # Animated WebP (https://github.com/vector-im/element-android/issues/2695).
+    convert_animated_webp_attachments: false
+
 facebook:
     device_seed: generate
     default_region_hint: ODN


### PR DESCRIPTION
Currently, WebP animated images cannot be played on the element for Android app (https://github.com/vector-im/element-android/issues/2695) This adds the configuration option `bridge.convert_animated_webp_attachments`  to transcode animated WebP images into a GIFs.