### PR TITLE
Proxy retries

### DIFF
--- a/maufbapi/http/api.py
+++ b/maufbapi/http/api.py
@@ -222,7 +222,7 @@ class AndroidAPI(LoginAPI, PostLoginAPI, UploadAPI, BaseAndroidAPI):
             "fb_api_req_friendly_name": "deleteMessages",
             "fb_api_caller_class": "MultiCacheThreadsQueue",
         }
-        resp = await self.http.post(
+        resp = await self.http_post(
             url=self.graph_url,
             data=params,
             headers=headers,
@@ -333,8 +333,8 @@ class AndroidAPI(LoginAPI, PostLoginAPI, UploadAPI, BaseAndroidAPI):
     async def get_self(self) -> OwnInfo:
         fields = ",".join(field.name for field in attr.fields(OwnInfo))
         url = (self.graph_url / str(self.state.session.uid)).with_query({"fields": fields})
-        async with self.get(url) as resp:
-            json_data = await self._handle_response(resp)
+        resp = await self.get(url)
+        json_data = await self._handle_response(resp)
         return OwnInfo.deserialize(json_data)
 
     async def logout(self) -> bool:
@@ -347,7 +347,7 @@ class AndroidAPI(LoginAPI, PostLoginAPI, UploadAPI, BaseAndroidAPI):
             "fb_api_req_friendly_name": "logout",
             "fb_api_caller_class": "AuthOperations",
         }
-        resp = await self.http.post(
+        resp = await self.http_post(
             url=self.b_graph_url / "auth" / "expire_session", headers=headers, data=req
         )
         resp.raise_for_status()
@@ -368,7 +368,7 @@ class AndroidAPI(LoginAPI, PostLoginAPI, UploadAPI, BaseAndroidAPI):
         }
         if prev_token:
             query["prev_token"] = prev_token
-        resp = await self.http.post(
+        resp = await self.http_post(
             url=(self.graph_url / "v3.2" / "cdn_rmd").with_query(query),
             headers=headers,
         )

--- a/maufbapi/http/login.py
+++ b/maufbapi/http/login.py
@@ -42,7 +42,7 @@ class LoginAPI(BaseAndroidAPI):
             "access_token": self.state.application.access_token,
         }
         req_data = self.format(req, sign=False)
-        resp = await self.http.post(
+        resp = await self.http_post(
             self.graph_url.with_path("//pwd_key_fetch"), headers=self._headers, data=req_data
         )
         json_data = await self._handle_response(resp)
@@ -70,7 +70,7 @@ class LoginAPI(BaseAndroidAPI):
             "x-fb-request-analytics-tags": "FBMobileConfigTigonFetcher",
         }
         headers.pop("x-fb-rmd", None)
-        resp = await self.http.post(
+        resp = await self.http_post(
             self.b_graph_url / "mobileconfigsessionless", headers=headers, data=req_data
         )
         json_data = await self._handle_response(resp)
@@ -132,7 +132,7 @@ class LoginAPI(BaseAndroidAPI):
             "content-type": "application/x-www-form-urlencoded",
             "x-fb-friendly-name": req["fb_api_req_friendly_name"],
         }
-        resp = await self.http.post(
+        resp = await self.http_post(
             url=self.graph_url / "check_approved_machine", headers=headers, data=req
         )
         json_data = await self._handle_response(resp)
@@ -168,7 +168,7 @@ class LoginAPI(BaseAndroidAPI):
             "x-fb-friendly-name": req["fb_api_req_friendly_name"],
         }
         headers.pop("x-fb-rmd", None)
-        resp = await self.http.post(
+        resp = await self.http_post(
             url=self.b_graph_url / "auth" / "login", headers=headers, data=req_data
         )
         self.log.trace(f"Login response: {resp.status} {await resp.text()}")

--- a/maufbapi/http/post_login.py
+++ b/maufbapi/http/post_login.py
@@ -54,7 +54,7 @@ class PostLoginAPI(BaseAndroidAPI):
             **self._headers,
         }
         headers.pop("x-fb-rmd", None)
-        resp = await self.http.post(url=url, headers=headers, data=req_data)
+        resp = await self.http_post(url=url, headers=headers, data=req_data)
         await self._decompress_zstd(resp)
         self.log.trace(f"Fetch logged in user response: {await resp.text()}")
         resp_data = await self._handle_response(resp, batch_index=2 if post_login else 0)

--- a/maufbapi/http/upload.py
+++ b/maufbapi/http/upload.py
@@ -15,26 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-import asyncio
 import base64
 import hashlib
 import json
 import time
 import unicodedata
 
-from aiohttp import ClientConnectionError
-
 from ..types import UploadResponse
 from .base import BaseAndroidAPI
-
-try:
-    from aiohttp_socks import ProxyConnectionError, ProxyError, ProxyTimeoutError
-except ImportError:
-
-    class ProxyError(Exception):
-        pass
-
-    ProxyConnectionError = ProxyTimeoutError = ProxyError
 
 
 class UploadAPI(BaseAndroidAPI):
@@ -118,30 +106,11 @@ class UploadAPI(BaseAndroidAPI):
 
         self.log.trace("Sending upload with headers: %s", headers)
         file_id = hashlib.md5(data).hexdigest() + str(offline_threading_id)
-        attempt = 0
-        while True:
-            try:
-                resp = await self.http.post(
-                    self.rupload_url / path_type / file_id, headers=headers, data=data
-                )
-                break
-            except (
-                ProxyError,
-                ProxyTimeoutError,
-                ProxyConnectionError,
-                ClientConnectionError,
-                ConnectionError,
-                asyncio.TimeoutError,
-            ) as e:
-                wait = attempt * 2
-                attempt += 1
-                if attempt >= max_attempts:
-                    raise
-                self.log.warning(
-                    f"{type(e).__name__} while trying to upload media, "
-                    f"retrying in {wait} seconds: {e}"
-                )
-                await asyncio.sleep(wait)
+        resp = await self.http_post(
+            self.rupload_url / path_type / file_id,
+            headers=headers,
+            data=data,
+        )
         json_data = await self._handle_response(resp)
         self.log.trace("Upload response: %s %s", resp.status, json_data)
         return UploadResponse.deserialize(json_data)

--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -348,7 +348,7 @@ class Portal(DBPortal, BasePortal):
         headers = {"referer": f"fbapp://{source.state.application.client_id}/{referer}"}
         sandbox = cls.config["bridge.sandbox_media_download"]
         cls.log.trace("Reuploading file %s", url)
-        async with source.client.get(url, headers=headers, sandbox=sandbox) as resp:
+        async with source.client.raw_http_get(url, headers=headers, sandbox=sandbox) as resp:
             length = int(resp.headers["Content-Length"])
             if length > cls.matrix.media_config.upload_size:
                 raise ValueError("File not available: too large")

--- a/mautrix_facebook/puppet.py
+++ b/mautrix_facebook/puppet.py
@@ -215,11 +215,11 @@ class Puppet(DBPuppet, BasePuppet):
             graph_url = (source.client.graph_url / str(fbid) / "picture").with_query(
                 {"width": "1000", "height": "1000"}
             )
-            async with source.client.get(graph_url) as resp:
+            async with source.client.raw_http_get(graph_url) as resp:
                 if resp.status < 400:
                     data = await resp.read()
         if data is None:
-            async with source.client.get(url) as resp:
+            async with source.client.raw_http_get(url) as resp:
                 data = await resp.read()
         mime = magic.mimetype(data)
         return await intent.upload_media(

--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -353,26 +353,6 @@ class User(DBUser, BaseUser):
                 if action != "restore session":
                     await self._send_reset_notice(e)
                 raise
-            except (
-                ProxyError,
-                ProxyTimeoutError,
-                ProxyConnectionError,
-                ClientConnectionError,
-                ConnectionError,
-                asyncio.TimeoutError,
-            ) as e:
-                attempt += 1
-                wait = min(attempt * 10, 60)
-                self.log.warning(
-                    f"{e.__class__.__name__} while trying to {action}, "
-                    f"retrying in {wait} seconds: {e}"
-                )
-                await asyncio.sleep(wait)
-                if refresh_proxy_on_failure:
-                    self.proxy_handler.update_proxy_url(
-                        f"{e.__class__.__name__} while trying to {action}"
-                    )
-                    await self.on_proxy_update()
             except ResponseError:
                 if action != "restore session":
                     attempt += 1

--- a/mautrix_facebook/user.py
+++ b/mautrix_facebook/user.py
@@ -1118,6 +1118,8 @@ class User(DBUser, BaseUser):
     async def on_proxy_update(self, evt: ProxyUpdate | None = None) -> None:
         if self.client:
             self.client.setup_http()
+        if self.mqtt:
+            self.mqtt.setup_proxy()
 
     def stop_listen(self) -> None:
         if self.mqtt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ asyncpg>=0.20,<0.28
 ruamel.yaml>=0.15.94,<0.18
 commonmark>=0.8,<0.10
 python-magic>=0.4,<0.5
-mautrix>=0.19.5,<0.20
+mautrix>=0.19.6,<0.20
 pycryptodome>=3,<4
 paho-mqtt>=1.5,<2
 zstandard


### PR DESCRIPTION
Implements proxy retry logic in the base HTTP and MQTT APIs.

Have also tweaked sending `TRANSIENT_DISCONNECT` to match the IG bridge where it only sends after initial MQTT retries to avoid sending too many of them.