### PR TITLE
Fix unencrypted rooms (part 2)

### DIFF
--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -1036,7 +1036,7 @@ class Portal(DBPortal, BasePortal):
             and (forward or self.next_batch_id is None)
         ):
             self.log.debug("Sending dummy event to avoid forward extremity errors")
-            await self.az.intent.send_message_event(
+            await self.main_intent.send_message_event(
                 self.mxid, EventType("fi.mau.dummy.pre_backfill", EventType.Class.MESSAGE), {}
             )
 


### PR DESCRIPTION
Follow-up of 75b2a0d for #274  , to fix dummy events and delivery receipts for unencrypted DMs.