### PR TITLE
maufbapi: include py.typed (PEP 561)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setuptools.setup(
         "mautrix_facebook.web": ["static/*", "static/**/*"],
         "maufbapi.http": ["zstd-dict.dat"],
         "maufbapi.mqtt": ["topics.json"],
+        "maufbapi": ["py.typed"],
     },
     data_files=[
         (".", ["mautrix_facebook/example-config.yaml"]),


### PR DESCRIPTION
From https://peps.python.org/pep-0561/#packaging-type-information

> Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed
