### PR TITLE
Force reconnect if we don't get a MQTT response quickly

### DIFF
--- a/maufbapi/mqtt/conn.py
+++ b/maufbapi/mqtt/conn.py
@@ -662,7 +662,8 @@ class AndroidMQTT:
             )
             # If we don't have a response in req timeout / 2, force reconnect
             reconnect_handle = self._loop.call_later(
-                REQUEST_RESPONSE_TIMEOUT / 2, self._reconnect()
+                REQUEST_RESPONSE_TIMEOUT / 2,
+                lambda: self._loop.create_task(self._reconnect()),
             )
             fut.add_done_callback(lambda _: reconnect_handle.cancel())
             # If we don't have a response in req timeout, assume failed

--- a/maufbapi/mqtt/conn.py
+++ b/maufbapi/mqtt/conn.py
@@ -651,7 +651,7 @@ class AndroidMQTT:
                 await self.publish(topic, payload, prefix)
             except asyncio.TimeoutError:
                 self.log.warning("Publish timed out - try forcing reconnect")
-                self._reconnect()
+                await self._reconnect()
             except MQTTNotConnected:
                 self.log.warning(
                     "MQTT disconnected before PUBACK - wait a hot minute, we should get "


### PR DESCRIPTION
Reconnect happens at 30s, the original request timeout, and the overall timeout is now doubled to 60s.