### PR TITLE
Improve double_puppet_server_map explanation in example-config.yaml

### DIFF
--- a/mautrix_facebook/example-config.yaml
+++ b/mautrix_facebook/example-config.yaml
@@ -137,9 +137,11 @@ bridge:
     # Note that updating the m.direct event is not atomic (except with mautrix-asmux)
     # and is therefore prone to race conditions.
     sync_direct_chat_list: false
-    # Servers to always allow double puppeting from
+    # Servers to always allow double puppeting from and at what URL they can be reached.
+    # Changes aren't reflected for already logged in users until they logout- and
+    # login-matrix again.
     double_puppet_server_map:
-        example.com: https://example.com
+        example.com: https://matrix.example.com
     # Allow using double puppeting from any server with a valid client .well-known file.
     double_puppet_allow_discovery: false
     # Shared secrets for https://github.com/devture/matrix-synapse-shared-secret-auth


### PR DESCRIPTION
- Add an extra sentence to the example-config.yaml describing double_puppet_server_map to aid configuration and troubleshooting.
- Change the example to make specifying subdomains clearer.