### PR TITLE
Refactor MQTT error handling

### DIFF
--- a/maufbapi/mqtt/conn.py
+++ b/maufbapi/mqtt/conn.py
@@ -598,6 +598,8 @@ class AndroidMQTT:
             # Wait 1s * errors, max 5s for fast reconnect or die
             max_wait_seconds=5,
             multiply_wait_seconds=1,
+            # If connection stable for >1h, reset the error counter
+            reset_after_seconds=3600,
         )
 
         if self._event_dispatcher_task:

--- a/maufbapi/mqtt/conn.py
+++ b/maufbapi/mqtt/conn.py
@@ -63,7 +63,7 @@ T = TypeVar("T")
 no_prefix_topics = (RealtimeTopic.TYPING_NOTIFICATION, RealtimeTopic.ORCA_PRESENCE)
 fb_topic_regex = re.compile(r"^(?P<topic>/[a-z_]+|\d+)(?P<extra>[|/#].+)?$")
 
-REQUEST_TIMEOUT = 60
+REQUEST_TIMEOUT = 60 * 3
 DEFAULT_KEEPALIVE = 60
 REQUEST_KEEPALIVE = 5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ asyncpg>=0.20,<0.28
 ruamel.yaml>=0.15.94,<0.18
 commonmark>=0.8,<0.10
 python-magic>=0.4,<0.5
-mautrix>=0.19.14,<0.20
+mautrix>=0.19.15,<0.20
 pycryptodome>=3,<4
 paho-mqtt>=1.5,<2
 zstandard


### PR DESCRIPTION
This removes a bunch of logic we have added to handle MQTT connection issues and instead utilises the clients builtin mechanisms. Achieved by overwriting the keepalive value temporarily while doing send/receive to force quicker detection of connection issues.

Needs testing, but looks like it could work!

https://github.com/mautrix/python/pull/148 would be handy to have here for the listen call.