### PR TITLE
invite bot on room creation so that it can invite ghost later if needed

### DIFF
--- a/mautrix_facebook/portal.py
+++ b/mautrix_facebook/portal.py
@@ -672,8 +672,9 @@ class Portal(DBPortal, BasePortal):
                     "content": self.get_encryption_state_event_json(),
                 }
             )
-            if self.is_direct:
-                invites.append(self.az.bot_mxid)
+            
+        if self.is_direct:
+            invites.append(self.az.bot_mxid)
 
         info = await self.update_info(source, info=info)
         if not info:


### PR DESCRIPTION
Fix for https://github.com/mautrix/facebook/issues/314

When not using double puppetting, it would create one-on-one chat rooms with just the user and the bot for the other person. Later, the main bot would attempt to invite the user's ghost into the room, but the main bot itself had never been invited to the room and hence the exception would be thrown. This fix ensures the main bot is always added to the invite list on room creation, meaning that it can later invite ghosts if it needs to.