### PR TITLE
fix: missing OwnInfo import

### DIFF
--- a/maufbapi/http/api.py
+++ b/maufbapi/http/api.py
@@ -39,6 +39,7 @@ from ..types import (
     MinimalThreadListResponse,
     MoreMessagesQuery,
     MoreThreadsQuery,
+    OwnInfo,
     ReactionAction,
     SearchEntitiesNamedQuery,
     SearchEntitiesResponse,

--- a/maufbapi/types/__init__.py
+++ b/maufbapi/types/__init__.py
@@ -16,6 +16,7 @@ from .graphql import (
     MoreMessagesQuery,
     MoreThreadsQuery,
     NTContext,
+    OwnInfo,
     ReactionAction,
     SearchEntitiesNamedQuery,
     SearchEntitiesResponse,


### PR DESCRIPTION
`get_self()` cannot be awaited without this fix:

```
   File "/venv/lib/python3.11/site-packages/maufbapi/http/api.py", line 344, in get_self
     fields = ",".join(field.name for field in attr.fields(OwnInfo))
                                                           ^^^^^^^
 NameError: name 'OwnInfo' is not defined
```